### PR TITLE
Corrected help text for fink cleanup.

### DIFF
--- a/perlmod/Fink/Engine.pm
+++ b/perlmod/Fink/Engine.pm
@@ -1095,8 +1095,10 @@ sub cmd_cleanup {
 			"Print the items that would be removed, but do not actually remove them." ],
 	], \@_, helpformat => <<HELPFORMAT,
 %intro{[mode(s) and options]}
-One or more of the following modes must be specified:
+The following modes can be specified:
 %opts{debs,sources,buildlocks,dpkg-status,obsolete-packages,all}
+
+If no mode is specified, the default is --debs --sources.
 
 Options:
 %opts{keep-src,dry-run,help}


### PR DESCRIPTION
The output of fink cleanup --help is incorrect because you don't have to specify any option at all. This corrects it. This patch was previously submitted to the SourceForge tracker:

https://sourceforge.net/tracker/?func=detail&aid=3294555&group_id=17203&atid=317203
