### PR TITLE
Support additional compression formats.

### DIFF
--- a/perlmod/Fink/PkgVersion.pm
+++ b/perlmod/Fink/PkgVersion.pm
@@ -3417,18 +3417,17 @@ GCC_MSG
 
 		# Determine the name of the TarFilesRename in the case of multi tarball packages
 		$renamefield = "Tar".$suffix."FilesRename";
-
 		$renamelist = "";
-
-		# Determine the rename list (if any)
 
 		# Note: the Apple-supplied /usr/bin/gnutar in versions 10.2 and
 		# earlier does not know about the flags --no-same-owner and
 		# --no-same-permissions.  Therefore, we do not use these in
 		# the "default" situation (which should only occur during bootstrap).
 
+		$tarflags = "-x${verbosity}f";
 		my $permissionflags = " --no-same-owner --no-same-permissions";
-		$tarcommand = "/usr/bin/gnutar $tarflags $permissionflags"; # Default to Apple's GNU Tar
+		$tarcommand = "/usr/bin/gnutar $permissionflags $tarflags"; # Default to Apple's GNU Tar
+		# Determine the rename list (if any)
 		if ($self->has_param($renamefield)) {
 			@renamefiles = split(/\s+/, $self->param($renamefield));
 			foreach $renamefile (@renamefiles) {
@@ -3442,11 +3441,11 @@ GCC_MSG
 			$tarcommand = "/bin/pax -r${verbosity}"; # Use pax for extracting with the renaming feature
 			$tar_is_pax=1; # Flag denoting that we're using pax
 		} elsif ( -e "$basepath/bin/tar" ) {
-			$tarcommand = "$basepath/bin/tar $tarflags $permissionflags"; # Use Fink's GNU Tar if available
+			$tarcommand = "$basepath/bin/tar $permissionflags $tarflags"; # Use Fink's GNU Tar if available
 		}
 		$bzip2 = $config->param_default("Bzip2path", 'bzip2');
 		$bzip2 = 'bzip2' unless (-x $bzip2);
-		$alt_bzip2=1 if ($bzip2 ne 'bzip2')
+		$alt_bzip2=1 if ($bzip2 ne 'bzip2');
 		$unzip = "unzip";
 		$gzip = "gzip";
 		$cat = "/bin/cat";
@@ -3456,22 +3455,22 @@ GCC_MSG
 		$unpack_cmd = "cp $found_archive ."; # non-archive file
 		# check for a tarball
 		if ($archive =~ /[\.\-]tar$/ or $archive =~ /[\.\-]t.*(z|Z).*/) {
-			if !($tar_is_pax) {  # No SourceFileNRename
+			if (!$tar_is_pax) {  # No SourceFileNRename
 				# Using "bzip2" for "bzip2" or if we're not on a bzipped tarball
-				if !($alt_bzip2 and $archive =~ /[\.\-]t(ar\.)?bz2?$/) { 
+				if (!($alt_bzip2 and $archive =~ /[\.\-]t(ar\.)?bz2?$/)) { 
 					$unpack_cmd = "$tarcommand $found_archive"; #let tar figure it out 
 				} else { # we're on a bzipped tar archive with an alternative bzip2
 					$unpack_cmd = "$bzip2 -dc $found_archive | $tarcommand -";
 				}
 			# Otherwise we're using pax and need to iterate through the uncompress options:
 			} elsif ($archive =~ /[\.\-]tar\.(gz|z|Z)$/ or $archive =~ /\.tgz$/) {
-				$unpack_cmd = "$gzip -dc $found_archive | $tarcommand $renamelist -";
+				$unpack_cmd = "$gzip -dc $found_archive | $tarcommand $renamelist";
 			} elsif ($archive =~ /[\.\-]t(ar\.)?bz2?$/) {
-				$unpack_cmd = "$bzip2 -dc $found_archive | $tarcommand $renamelist -";
+				$unpack_cmd = "$bzip2 -dc $found_archive | $tarcommand $renamelist";
 			} elsif ($archive =~ /[\.\-]tar\.xz$/) {
-				$unpack_cmd = "$xz -dc $found_archive | $tarcommand $renamelist -";
+				$unpack_cmd = "$xz -dc $found_archive | $tarcommand $renamelist";
 			} elsif ($archive =~ /[\.\-]tar$/) {
-				$unpack_cmd = "$cat $found_archive | $tarcommand $renamelist -";
+				$unpack_cmd = "$cat $found_archive | $tarcommand $renamelist";
 			}
 		# Zip file
 		} elsif ($archive =~ /\.[zZ][iI][pP]$/) {


### PR DESCRIPTION
We can let tar (even Apple's on 10.5+) figure out what uncompression program to call, and thus support .tar.xz archives.

Unfortunately, it's not _quite_ that simple, since TarFilesRename uses pax instead of tar, so we still have to have a finite number of filetypes that we can uncompress and feed to pax.
