### PR TITLE
Validation for packages that use tar.xz archives

### DIFF
--- a/perlmod/Fink/Validation.pm
+++ b/perlmod/Fink/Validation.pm
@@ -23,7 +23,7 @@
 
 package Fink::Validation;
 
-use Fink::Services qw(&read_properties &read_properties_var &expand_percent &expand_percent2 &file_MD5_checksum &pkglist2lol &version_cmp &filename);
+use Fink::Services qw(&read_properties &read_properties_var &expand_percent &expand_percent2 &file_MD5_checksum &pkglist2lol &version_cmp);
 use Fink::Config qw($config);
 use Cwd qw(getcwd);
 use File::Find qw(find);


### PR DESCRIPTION
Verify that packages Bdep on xz, and verify Bdep on fink (>=0.31.7)
(if it gets released then)
