### PR TITLE
Enable fink to find Xcode version with Xcode 4.3.

### DIFF
--- a/perlmod/Fink/VirtPackage.pm
+++ b/perlmod/Fink/VirtPackage.pm
@@ -668,9 +668,9 @@ you can download it from Apple at:
 END
 	$hash->{compilescript} = &gen_compile_script($hash);
 
-	my $result = `defaults read /Developer/Applications/Xcode.app/Contents/version CFBundleShortVersionString 2>&1`;
+	my $result = `defaults read /Applications/Xcode.app/Contents/version CFBundleShortVersionString 2>&1`;
 	if ($?) {
-		$result = `defaults read /Applications/Xcode.app/Contents/version CFBundleShortVersionString 2>&1`;
+		$result = `defaults read /Developer/Applications/Xcode.app/Contents/version CFBundleShortVersionString 2>&1`;
 	}
 	if (not $?) {
 		# didn't fail


### PR DESCRIPTION
VirtPackage.pm currently checks for Xcode in /Developer/Applications. This patch also checks in /Applications if that fails since that's where Xcode 4.3 goes now.
