### PR TITLE
Branch 0 33 add auto md5sums generation

### DIFF
--- a/perlmod/Fink/ChangeLog
+++ b/perlmod/Fink/ChangeLog
@@ -1,3 +1,9 @@
+2012-06-28  Justin F. Hallett  <thesin@users.sourceforge.net>
+
+	* PkgVersion.pm: add auto DEBIAN/md5sums file generation, this is the
+	  first rough draft, 'find' call should be File::Find, and maybe
+	  'md5sum' call might need to be a pure perl function at somepoint.
+
 2011-11-06  Daniel Macks  <dmacks@netspace.org>
 
 	* Engine.pm (cmd_dumpinfo): add missing parameter (recently added


### PR DESCRIPTION
This patch is to auto create and include the DEBIAN/md5sums file for future use of debsums pkg and other security and auditing tools.  Since fink has never used the md5sums file it's will take a while to populate current installs but in the future this will be very useful to help uses with issues that have local modifications and help developers with the same.  It is also a great security tool, so make sure nothing or no one on the system is changing files like a rootkit.
