### PR TITLE
Add providers as dependencies of virtual packages

### DIFF
--- a/perlmod/Fink/Engine.pm
+++ b/perlmod/Fink/Engine.pm
@@ -655,6 +655,12 @@ sub do_real_list {
 						print "\"$pname\" -> \"$1\";\n";
 					}
 				}
+			} else {
+				my @providers = $package->get_all_providers();
+				for my $provider (@providers) {
+					my $name = $provider->get_name();
+					print "\"$pname\" -> \"$name\";\n";
+				}
 			}
 		} else {
 			printf $formatstr,


### PR DESCRIPTION
This feature makes it possible for me to get the information needed to topologically sort the set of packages I'm going to build in one call to fink list -f dotty-build.
