### PR TITLE
Fix resolution of PatchFileN and PatchFileN-md5 in "fink dumpinfo"

### DIFF
--- a/perlmod/Fink/Engine.pm
+++ b/perlmod/Fink/Engine.pm
@@ -2494,7 +2494,7 @@ HELPFORMAT
 					 $_ =~ /^tar\d*filesrename$/ or
 					 $_ =~ /^update(configguess|libtool)indirs$/ or
 					 $_ =~ /^set/ or $_ =~ /^jarfiles$/ or
-					 $_ =~ /^patch(|\d*file|\d*file-md5)$/ or $_ eq 'appbundles' or
+					 $_ =~ /^patch(|file\d*|file\d*-md5)$/ or $_ eq 'appbundles' or
  					 $_ eq 'infodocs' or $_ =~ /^daemonicname$/
 					) {
 				# singleline fields start on the same line, have


### PR DESCRIPTION
Prior to applying this change, "fink dumpinfo" fails to resolve when it hits a PatchFileN, e.g. `fink dumpinfo flac` ends prematurely with

[]
builddependsonly: true
source: mirror:sourceforge:flac/flac-1.2.1.tar.gz
source-md5: 153c8b15a54da428d1f0fadc756c22c7
nosourcedirectory: [undefined]
patchfile: flac.patch
patchfile-md5: 5c41b21888c325ba7d77dcc67e24ac9b
Failed: Unknown field patchfile2
