### PR TITLE
Make sure gcc_selected() returns something useful on Xcode 5.

### DIFF
--- a/perlmod/Fink/Services.pm
+++ b/perlmod/Fink/Services.pm
@@ -1261,6 +1261,10 @@ sub gcc_selected {
 		} else {
 			print STDERR "WARNING: /usr/bin/gcc is not a symlink!";
 		}
+	} elsif (-x '/usr/bin/gcc') {
+		if (`/usr/bin/gcc --version` =~ /clang/) {
+			return "4.2";
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
On Xcode 5, /usr/bin/gcc is no longer a symlink but actually clang.
This causes Fink::Services::gcc_selected() to return "0" which prevents
fink from installing. It would also break installing packages with a
GCC field. This patch always returns "4.2" when gcc is clang.
