### PR TITLE
fix string concat errors from JDK dir names

### DIFF
--- a/perlmod/Fink/VirtPackage.pm
+++ b/perlmod/Fink/VirtPackage.pm
@@ -404,8 +404,16 @@ directories exist.
 					$java_cmd_dir = "$dir/Commands";
 				} else { # 1.7 and later, including older formats
 					($dir) = ($javadir =~ m|(\d+\.\d+\.\d+).*jdk|) ;
+					if (not defined $dir) {
+						print STDERR "  - warning, unsure how to handle Java directory $dir\n" if ($options{debug});
+						next;
+					}
 					$java_test_dir = "$javadir/bin";
 					($java_cmd_dir) = ($java_test_dir =~ m|/.*/((.*)?jdk/.*/bin)|);
+					if (not defined $java_cmd_dir) {
+						print STDERR "  - warning, unsure how to determine Java command directory from $java_test_dir\n" if ($options{debug});
+						next;
+					}
 					$java_inc_dir = $java_cmd_dir;
 					$java_inc_dir =~ s/bin/include/;
 				}


### PR DESCRIPTION
I have a number of funkily-named JDKs that aren't meant to be
picked up by fink, which cause output like this:

Use of uninitialized value $java_inc_dir in substitution (s///) at /sw/lib/perl5/Fink/VirtPackage.pm line 410.
Use of uninitialized value $dir in concatenation (.) or string at /sw/lib/perl5/Fink/VirtPackage.pm line 420.
Use of uninitialized value $dir in concatenation (.) or string at /sw/lib/perl5/Fink/VirtPackage.pm line 421.
Use of uninitialized value $dir in concatenation (.) or string at /sw/lib/perl5/Fink/VirtPackage.pm line 427.
Use of uninitialized value $dir in pattern match (m//) at /sw/lib/perl5/Fink/VirtPackage.pm line 433.

This patch tells fink to print a warning (if debug enabled)
and skip those JDKs.
