### PR TITLE
Enable binary distributions.

### DIFF
--- a/perlmod/Fink/Config.pm
+++ b/perlmod/Fink/Config.pm
@@ -735,7 +735,7 @@ EOF
 	# We only include the remote debs if the bindist looks like it's ok
 	if (!$self->bindist_check_prefix && !$self->bindist_check_distro) {
 
-		my $apt_mirror = "http://us.dl.sourceforge.net/fink/direct_download";
+		my $apt_mirror = "http://bindist.finkmirrors.net";
 
 		if ($self->has_param("Mirror-apt")) {
 			$apt_mirror = $self->param("Mirror-apt");
@@ -748,14 +748,8 @@ EOF
 # Official binary distribution: download location for packages
 # from the latest release
 EOF
-
-	$body .= "deb $apt_mirror $distribution/release $apt_trees\n\n";
-		$body .= <<EOF;
-# Official binary distribution: download location for updated
-# packages built between releases
-EOF
-
-	$body .= "deb $apt_mirror $distribution/current $apt_trees\n\n";
+	# bindist structure for supported distros as of 3/2014.  
+	$body .= "deb $apt_mirror/$distribution stable $apt_trees\n\n";
 
 	}
 

--- a/perlmod/Fink/FinkVersion.pm.in
+++ b/perlmod/Fink/FinkVersion.pm.in
@@ -106,7 +106,17 @@ distro for the given $distribution.
 sub default_binary_version {
 	my $distribution = shift;
 	my $architecture = get_arch();
-	my %bindists = ("10.2-gcc3.3/powerpc" => "0.6.4", "10.3/powerpc" => "0.7.2", "10.4-transitional/powerpc" => "0.8.0", "10.4/powerpc" => "0.8.1", "10.4/i386" => "0.8.1", "10.5/powerpc" => "0.9.0", "10.5/i386" => "0.9.0");
+	my %bindists = (
+					"10.2-gcc3.3/powerpc" => "0.6.4",
+					"10.3/powerpc" => "0.7.2",
+					"10.4-transitional/powerpc" => "0.8.0",
+					"10.4/powerpc" => "0.8.1",
+					"10.4/i386" => "0.8.1",
+					"10.5/powerpc" => "0.9.0",
+					"10.5/i386" => "0.9.0",
+					"10.8/x86_64" => "0.12.0",
+					"10.9/x86_64" => "0.13.0",
+					);
 	return $bindists{"$distribution/$architecture"};
 }
 


### PR DESCRIPTION
This restores binary distribution service for supported OS versions.  fink-mirrors-0.36.3.2 and later already includes the proper bindist information.
