### PR TITLE
Remove -Wno-error=unused-command-line-argument-hard-error-in-future usin...

### DIFF
--- a/compiler_wrapper-10.7.in
+++ b/compiler_wrapper-10.7.in
@@ -20,7 +20,8 @@ fi
 # To avoid extra warning spew, don't add 
 # -Wno-error=unused-command-line-argument-hard-error-in-future
 # when clang doesn't support it .
-if [[ "`clang --version | head -n1 | cut -d- -f2 | cut -d')' -f1`" < "503.0.38" ]]; then
+clang_version=`clang --version | head -n1 | cut -d- -f2 | cut -d'.' -f1`
+if [[ ($clang_version -lt "503") || ($clang_version -ge "600") ]]; then
 	suppress_hard_error=""
 else
 	suppress_hard_error="-Wno-error=unused-command-line-argument-hard-error-in-future"

--- a/compiler_wrapper-10.9.in
+++ b/compiler_wrapper-10.9.in
@@ -14,7 +14,8 @@ export PATH="$newpath"
 # To avoid extra warning spew, don't add 
 # -Wno-error=unused-command-line-argument-hard-error-in-future
 # when clang doesn't support it .
-if [[ `clang --version | head -n1 | cut -d- -f2 | cut -d')' -f1` < "503.0.38" ]]; then
+clang_version=`clang --version | head -n1 | cut -d- -f2 | cut -d'.' -f1`
+if [[ ($clang_version -lt "503") || ($clang_version -ge "600") ]]; then
 	suppress_hard_error=""
 else
 	suppress_hard_error="-Wno-error=unused-command-line-argument-hard-error-in-future"

--- a/perlmod/Fink/PkgVersion.pm
+++ b/perlmod/Fink/PkgVersion.pm
@@ -4834,7 +4834,8 @@ export PATH="\$newpath"
 # To avoid extra warning spew, don't add 
 # -Wno-error=unused-command-line-argument-hard-error-in-future
 # when clang doesn't support it .
-if [[ `clang --version | head -n1 | cut -d- -f2 | cut -d')' -f1` < "503.0.38" ]]; then
+clang_version=`clang --version | head -n1 | cut -d- -f2 | cut -d'.' -f1`
+if [[ (\$clang_version -lt "503") || (\$clang_version -ge "600") ]]; then
 	suppress_hard_error=""
 else
 	suppress_hard_error="-Wno-error=unused-command-line-argument-hard-error-in-future"
@@ -4898,7 +4899,8 @@ fi
 # To avoid extra warning spew, don't add 
 # -Wno-error=unused-command-line-argument-hard-error-in-future
 # when clang doesn't support it .
-if [[ "`clang --version | head -n1 | cut -d- -f2 | cut -d')' -f1`" < "503.0.38" ]]; then
+clang_version=`clang --version | head -n1 | cut -d- -f2 | cut -d'.' -f1`
+if [[ (\$clang_version -lt "503") || (\$clang_version -ge "600") ]]; then
 	suppress_hard_error=""
 else
 	suppress_hard_error="-Wno-error=unused-command-line-argument-hard-error-in-future"


### PR DESCRIPTION
...g clang 6+

The -Wno-error=unused-command-line-argument-hard-error-in-future flag is no longer supported or necessary in clang 6 so only add it for clang 5. Also simplify the clang version checking code since bash doesn't let one really compare version numbers in the form of "x.y.z". Only compare "x" since that's all we need.
