### PR TITLE
Roll back allowing just /opt/X11 as sufficient for system-xfree86*.

### DIFF
--- a/perlmod/Fink/VirtPackage.pm
+++ b/perlmod/Fink/VirtPackage.pm
@@ -1455,7 +1455,9 @@ virtual packages. (See &package_from_pkgconfig).
 =cut
 
 	our @x11_dirs=('/usr/X11','/usr/X11R6'); # Put the real directory at the left
-	unshift (@x11_dirs,'/opt/X11') if $osxversion >= 12 ; # Xquartz is supported only for Mountain Lion and later 
+#   uncomment the line below when 10.7 and 10.8 are no longer supported, or 
+#   better yet, just put /opt/X11 above without a conditional.
+#	unshift (@x11_dirs,'/opt/X11') if $osxversion >= 12 ; # Xquartz is supported only for Mountain Lion and later 
 	for my $base_dir (@x11_dirs, '/usr') {
 		my $dir = "$base_dir/lib/pkgconfig";
 		next unless (-d $dir);

--- a/perlmod/Fink/VirtPackage.pm
+++ b/perlmod/Fink/VirtPackage.pm
@@ -1454,7 +1454,7 @@ virtual packages. (See &package_from_pkgconfig).
 
 =cut
 
-	our @x11_dirs=('/usr/X11','/usr/X11R6'); # Put the real directory at the left
+	our @x11_dirs=('/usr/X11R6'); 
 #   uncomment the line below when 10.7 and 10.8 are no longer supported, or 
 #   better yet, just put /opt/X11 above without a conditional.
 #	unshift (@x11_dirs,'/opt/X11') if $osxversion >= 12 ; # Xquartz is supported only for Mountain Lion and later 


### PR DESCRIPTION
When I merged PR# 116, I had completely forgotten that there was potential breakage for somebody upgrading on the supported path from 10.7 to 10.8 if they didn't have /usr/X11 -> /opt/X11.

* Binaries that link X11 libraries as built on 10.7 have install_names /usr/X11* encoded.
* On the 10.7 -> 10.8 update, /usr/X11 and /usr/X11R6 are blown away.
* The $user installs Xquartz to provide X11, and it theoretically _should_ put in the /usr/X11R6 -> /opt/X11 and /usr/X11 -> /opt/X11 convenience symlinks, but this doesn't always happen.
* Without the change, even in the absence of the symlinks the system-xfree86* and therefore x11* packages will show up as installed, even though for the purposes of the X11-using libraries already on the system this isn't the case, since they can't find /usr/X11.  New  builds that use those libraries will likely have problems.
* With the change system-xfree86* and therefore x11* won't be generated and there will be a dependency complaint when the $user tries to build new stuff.  Of course, there's not really an option to detect the existing runtime breakage.

Any thoughts about this?  It's a better user experience to get a dependency error before building rather than a library linkage error in the middle of the build, I guess.