### PR TITLE
Add the (L)GPL linking to OpenSSL variants to the list of allowed lic…

### DIFF
--- a/perlmod/Fink/Scanpackages.pm
+++ b/perlmod/Fink/Scanpackages.pm
@@ -506,7 +506,9 @@ sub _output {
 	return if !$self->{restrictive} && (
 		!exists $control->{'Fink-License'}
 		|| lc $control->{'Fink-License'} eq 'restrictive'
-		|| lc $control->{'Fink-License'} eq 'commercial');
+		|| lc $control->{'Fink-License'} eq 'commercial'
+		|| lc $control->{'Fink-License'} eq 'gpl/openssl'
+		|| lc $control->{'Fink-License'} eq 'lgpl/openssl');
 
 	# Order to output fields, from apt-pkg/tagfile.cc
 	my @fieldorder = qw(Package Essential Status Priority Section

--- a/perlmod/Fink/Validation.pm
+++ b/perlmod/Fink/Validation.pm
@@ -115,7 +115,7 @@ our %allowed_license_values = map {$_, 1}
 	 "GPL", "LGPL", "GPL/LGPL", "BSD", "Artistic", "Artistic/GPL", "GFDL",
 	 "GPL/GFDL", "LGPL/GFDL", "GPL/LGPL/GFDL", "LDP", "GPL/LGPL/LDP",
 	 "OSI-Approved", "Public Domain", "Restrictive/Distributable",
-	 "Restrictive", "Commercial", "DFSG-Approved"
+	 "Restrictive", "Commercial", "DFSG-Approved", "GPL/OpenSSL", "LGPL/OpenSSL"
 	);
 
 # Allowed values of the architecture field


### PR DESCRIPTION
…enses, and treat them as restrictive.

I'm not sure if the license string gets parsed into "Fink-License" with or without the slash punctuation.

The purpose of this change is to mark (L)GPL packages that link to OpenSSL as restrictive without changing the License field to just "Restrictive" and leaving a note in DescPackaging. These new license strings provide the same information in a quicker to understand manner and in a way which should minimize loss of information over time as a .info is updated (eg, "why was pkg X marked as Restrictive?? COPYING clearly says it is GPL...")