### PR TITLE
Add sandbox profile for fink to make /usr/local inaccessible while bu…

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ fink.in
 fink.8.in
 fink.conf.5.in
 fink.csh
+fink.sb
 fink.sh
 images/finkDoneFailed.png
 images/finkDonePassed.png

--- a/fink.sb
+++ b/fink.sb
@@ -1,0 +1,11 @@
+;;
+;; fink - sandbox profile
+;;
+
+(version 1)
+
+(allow default)
+
+(deny file*
+       (subpath "/usr/local")
+)

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,7 @@ fi
 
 install -c -p -m 755 postinstall.pl "$basepath/lib/fink/"
 install -c -p -m 644 shlibs.default "$basepath/etc/dpkg/"
+install -c -p -m 644 fink.sb "$basepath/etc/"
 install -c -p -m 644 fink.8 "$basepath/share/man/man8/"
 install -c -p -m 644 fink.conf.5 "$basepath/share/man/man5/"
 install -c -p -m 644 images/*.png "$basepath/share/fink/images/"

--- a/perlmod/Fink/Services.pm
+++ b/perlmod/Fink/Services.pm
@@ -594,6 +594,8 @@ EOSCRIPT
 		@wrap = map "$_=$ENV{$_}", sort keys %ENV;
 		push @wrap, "__CFPREFERENCES_AVOID_DAEMON=1";
 		unshift @wrap, 'env' if @wrap;
+		my $sandbox = "$Fink::Config::basepath/etc/fink.sb";
+		@wrap = (qw| sandbox-exec -f |, $sandbox, @wrap) if -f $sandbox;
 		my $sudo_cmd = "sudo -u " . Fink::Config::build_as_user_group()->{'user'};
 		@wrap = (split(' ', $sudo_cmd), @wrap, qw/ sh -c /);
 		$wrap_token = "$sudo_cmd [ENV] sh -c ";

--- a/t/Services/execute_nonroot_okay.t
+++ b/t/Services/execute_nonroot_okay.t
@@ -15,6 +15,8 @@ require_ok('Fink::Config');            # 3
 can_ok('Fink::Config','get_option');   # 4
 can_ok('Fink::Config','set_options');  # 5
 
+my $config_obj = Fink::Config->new_with_path('basepath/etc/fink.conf');
+
 # need a a safe place to create files
 
 # OS X 10.2 comes with perl 5.6.0, but File::Temp isn't in core until 5.6.1


### PR DESCRIPTION
…ilding.

The presence of /usr/local can make many packages fail, because it may cause
inappropriate library versions to be linked.