### PR TITLE
Allow Library/Launch{Agents,Daemons} directories inside %p

### DIFF
--- a/perlmod/Fink/Validation.pm
+++ b/perlmod/Fink/Validation.pm
@@ -1699,7 +1699,7 @@ sub _validate_dpkg {
 	my @bad_dirs = ( map "$basepath/$_/", qw( src man info doc libexec lib/locale bin/.* sbin/.* ) );
 	push(@bad_dirs, ( map ".*/$_/", qw( CVS RCS \.svn \.git \.hg ) ) ); # forbid version control residues
 
-	my @good_dirs = ( map "$basepath/$_/", qw( bin sbin include lib opt share var etc Applications Library/Frameworks Library/Python ) );
+	my @good_dirs = ( map "$basepath/$_/", qw( bin sbin include lib opt share var etc Applications Library/Frameworks Library/LaunchAgents Library/LaunchDaemons Library/Python ) );
 	# allow $basepath/Library/ by itself, but with nothing below it other than what we explicitly allowed already
 	# (needed since we allow $basepath/Library/Frameworks)
 	push(@good_dirs, "$basepath/Library/\$");


### PR DESCRIPTION
Allow the subdirectories LaunchAgents and LaunchDaemons inside %p/Library. This would be a common holding ground for packages to store their launchd .plist files before copying (or symlinking) over to /Library during PostInstScript. The alternative is that every package that uses launchd files stores their .plist file wherever the maintainer chooses and is not standardized.

In the future, files placed here could be automatically added to /Library/LaunchXYZ by dpkg during .deb installation.