### PR TITLE
Add more checksum providers for SHA-1 and SHA-256

### DIFF
--- a/perlmod/Fink/Checksum/SHA1.pm
+++ b/perlmod/Fink/Checksum/SHA1.pm
@@ -55,8 +55,13 @@ sub new {
 		} elsif (-x "/usr/bin/openssl") {
 			$sha1cmd = '/usr/bin/openssl sha1';
 			$match   = 'SHA1\([^\)]+\)\s*=\s*(\S+)';
-		} elsif (-e "$basepath/lib/coreutils/bin/sha1sum") {
+		} elsif (-x "$basepath/bin/openssl") {
+			$sha1cmd = '$basepath/bin/openssl sha1';
+			$match   = 'SHA1\([^\)]+\)\s*=\s*(\S+)';
+		} elsif (-x "$basepath/lib/coreutils/bin/sha1sum") {
 			$sha1cmd = "$basepath/lib/coreutils/bin/sha1sum";
+        } elsif (-x "/usr/bin/shasum") {
+            $sha256cmd = "/usr/bin/shasum -a 1 -b";
 		}
 	}
 

--- a/perlmod/Fink/Checksum/SHA256.pm
+++ b/perlmod/Fink/Checksum/SHA256.pm
@@ -45,17 +45,21 @@ sub new {
 
 	$match = '(\S*)\s*(:?\S*)';
 
-	if (-e "$basepath/bin/sha256deep") {
+	if (-x "$basepath/bin/sha256deep") {
 		$sha256cmd = "$basepath/bin/sha256deep";
-		} elsif (-x "/usr/bin/openssl") {
-			$sha256cmd = '/usr/bin/openssl dgst -sha256';
-			$match   = 'SHA256\([^\)]+\)\s*=\s*(\S+)';
-		} elsif (-e "$basepath/lib/coreutils/bin/sha256sum") {
-			$sha256cmd = "$basepath/lib/coreutils/bin/sha256sum";
-
+    } elsif (-x "/usr/bin/openssl") {
+        $sha256cmd = '/usr/bin/openssl dgst -sha256';
+        $match   = 'SHA256\([^\)]+\)\s*=\s*(\S+)';
+    } elsif (-x "$basepath/openssl") {
+        $sha256cmd = '$basepath/openssl dgst -sha256';
+        $match   = 'SHA256\([^\)]+\)\s*=\s*(\S+)';
+    } elsif (-x "$basepath/lib/coreutils/bin/sha256sum") {
+        $sha256cmd = "$basepath/lib/coreutils/bin/sha256sum";
+    } elsif (-x "/usr/bin/shasum") {
+        $sha256cmd = "/usr/bin/shasum -a 256 -b";
 	}
 
-	if (!defined $sha256cmd or not -x $sha256cmd) {
+	if (!defined $sha256cmd) {
 		die "unable to find sha256 implementation. Try installing md5deep or coreutils\n";
 	}
 


### PR DESCRIPTION
Namely try Fink's openssl, as well as /usr/bin/shasum (the latter is part of Perl)

This makes it much more convenient to use SHA256 instead of MD5 in .info files, I think.