### PR TITLE
Various checksum related changes

### DIFF
--- a/fink.info.in
+++ b/fink.info.in
@@ -11,6 +11,7 @@ Replaces: gcc3.1 (= 1175-6)
 Essential: yes
 Source: @SOURCE@
 Source-MD5: @MD5@
+Source-Checksum: SHA256(@SHA@)
 NoSetPATH: true
 BuildAsNobody: false
 CompileScript: <<

--- a/perlmod/Fink/Bootstrap.pm
+++ b/perlmod/Fink/Bootstrap.pm
@@ -820,7 +820,7 @@ $bpath/fink/dists/$destination/$target_file if it already exists.
 
 Next, copy $template_file (from the current directory) to
 $bpath/fink/dists/$destination/$target_file, supplying the correct
-$packageversion and $packagerevision as well as an MD5 sum calculated from
+$packageversion and $packagerevision as well as the MD5 and SHA256 sums calculated from
 $bpath/src/$package-$packageversion.tar.  Ensure that the created file
 has mode 644.
 
@@ -902,7 +902,7 @@ sub copy_description {
 
 Copy the file $original to $target, supplying the correct version, revision,
 and distribution (from get_version_revision($package_source,$distribution))
-as well as $source_location and an MD5 sum calculated from $tarball.
+as well as $source_location and the MD5 and SHA256 sums calculated from $tarball.
 Pre-evaluate any conditionals containing %{Distribution}, using
 $distribution as the value of %{Distribution}.  Append $coda to the end
 of the file.
@@ -930,6 +930,8 @@ sub modify_description {
 	print "Modifying package description...\n";
 	my $md5obj = Fink::Checksum->new('MD5');
 	my $md5 = $md5obj->get_checksum($tarball);
+	my $sha256obj = Fink::Checksum->new('SHA256');
+	my $sha256 = $sha256obj->get_checksum($tarball);
 
 	my $result = 0;
 
@@ -942,6 +944,7 @@ sub modify_description {
 		$_ =~ s/\@REVISION\@/$revision/;
 		$_ =~ s/\@SOURCE\@/$source_location/;
 		$_ =~ s/\@MD5\@/$md5/;
+		$_ =~ s/\@SHA256\@/$sha256/;
 		$_ =~ s/\@DISTRIBUTION\@/$distribution/;
 # only remove conditionals which match "%{Distribution}" (and we will
 # remove the entire line if the condition fails)

--- a/perlmod/Fink/Engine.pm
+++ b/perlmod/Fink/Engine.pm
@@ -2481,20 +2481,21 @@ HELPFORMAT
 			foreach ($pkg->get_source_suffixes) {
 				if ($_ eq "") {
 					push @fields, (qw/
-								   source sourcerename source-md5
+								   source sourcerename
+								   source-checksum source-md5
 								   nosourcedirectory sourcedirectory
 								   tarfilesrename
 								   /);
 				} else {
 					push @fields, ("source${_}", "source${_}rename",
-								   "source${_}-md5",
+								   "source${_}-checksum", "source${_}-md5",
 								   "source${_}extractdir",
 								   "tar${_}filesrename"
 								  );
 				}
 			}
 			foreach ($pkg->get_patchfile_suffixes) {
-				push @fields, ( "patchfile${_}", "patchfile${_}-md5" );
+				push @fields, ( "patchfile${_}", "patchfile${_}-checksum", "patchfile${_}-md5" );
 			}
 			push @fields, (qw/
 						   updateconfigguess updateconfigguessindirs
@@ -2622,7 +2623,7 @@ HELPFORMAT
 			} elsif ($_ =~ /^source(\d*)$/) {
 				my $src = $pkg->get_source($1);
 				printf "%s: %s\n", $_, $src if defined $src && $src ne "none";
-			} elsif ($_ eq 'gcc' or $_ =~ /^source\d*-md5$/) {
+			} elsif ($_ eq 'gcc' or $_ =~ /^source\d*-md5$/ or $_ =~ /^source\d*-checksum$/) {
 				printf "%s: %s\n", $_, $pkg->param($_) if $pkg->has_param($_);
 			} elsif ($_ eq 'configureparams') {
 				my $cparams = &expand_percent(
@@ -2635,7 +2636,7 @@ HELPFORMAT
 					 $_ =~ /^tar\d*filesrename$/ or
 					 $_ =~ /^update(configguess|libtool)indirs$/ or
 					 $_ =~ /^set/ or $_ =~ /^jarfiles$/ or
-					 $_ =~ /^patch(|file\d*|file\d*-md5)$/ or $_ eq 'appbundles' or
+					 $_ =~ /^patch(|file\d*|file\d*-md5|file\d*-checksum)$/ or $_ eq 'appbundles' or
  					 $_ eq 'infodocs' or $_ =~ /^daemonicname$/
 					) {
 				# singleline fields start on the same line, have

--- a/perlmod/Fink/PkgVersion.pm
+++ b/perlmod/Fink/PkgVersion.pm
@@ -27,7 +27,7 @@ use Fink::Services qw(&filename &execute
 					  &expand_percent &expand_percent2 &latest_version
 					  &collapse_space &read_properties &read_properties_var
 					  &pkglist2lol &lol2pkglist &cleanup_lol
-					  &file_MD5_checksum &version_cmp
+					  &version_cmp
 					  &get_system_perl_version
 					  &get_path &eval_conditional &enforce_gcc
 					  &dpkg_lockwait &aptget_lockwait &lock_wait
@@ -3662,11 +3662,27 @@ sub phase_patch {
 			# file exists
 			die "Cannot read PatchFile$suffix \"$file\"\n" unless -r $file;
 
-			# verify that MD5 matches
-			my $md5 = $self->param_default("PatchFile$suffix-MD5", '');
-			my $file_md5 = file_MD5_checksum($file);  # old API so we are back-portable to branch_0-24
-			if ($md5 ne $file_md5) {
-				die "PatchFile$suffix \"$file\" checksum does not match!\nActual: $file_md5\nExpected: $md5\n";
+			# verify the checksum matches (at least one of -Checksum or -MD5 must be present)
+			if (not $self->has_param("PatchFile$suffix-MD5") and not $self->has_param("PatchFile$suffix-Checksum")) {
+				die "No checksum specified for PatchFile$suffix \"$file\"!\n";
+			}
+			if ($self->has_param("PatchFile$suffix-Checksum")) {
+				my $checksum = $self->param("PatchFile$suffix-Checksum");
+				if (not Fink::Checksum->validate($file, $checksum)) {
+					my %archive_sums = %{Fink::Checksum->get_all_checksums($file)};
+					die "PatchFile$suffix \"$file\" checksum does not match!\n".
+						"Expected: $checksum\nActual: " .
+						join("        ", map "$_($archive_sums{$_})\n", sort keys %archive_sums);
+				}
+			}
+			if ($self->has_param("PatchFile$suffix-MD5")) {
+				my $checksum = "MD5(" . $self->param("PatchFile$suffix-MD5") . ")";
+				if (not Fink::Checksum->validate($file, $checksum)) {
+					my %archive_sums = %{Fink::Checksum->get_all_checksums($file)};
+					die "PatchFile$suffix \"$file\" checksum does not match!\n".
+						"Expected: $checksum\nActual: " .
+						join("        ", map "$_($archive_sums{$_})\n", sort keys %archive_sums);
+				}
 			}
 
 			# check that we're contained in a world-executable directory
@@ -4053,7 +4069,7 @@ sub phase_build {
 			for my $suffix ($build_pkg->get_patchfile_suffixes()) {
 				my $patchfile = &expand_percent("\%{PatchFile$suffix}", $build_pkg->{_expand}, $self->get_info_filename." \"PatchFile$suffix\"");
 				# only get here after successful build, so we know
-				# patchfile was present, readable, and matched MD5
+				# patchfile was present, readable, and matched checksum
 				cp($patchfile, "$destdir/DEBIAN/package.patch$suffix");
 			}
 		}

--- a/perlmod/Fink/Scanpackages.pm
+++ b/perlmod/Fink/Scanpackages.pm
@@ -603,12 +603,8 @@ sub _prefix {
 #### Deal with different versions of Fink
 
 # Get MD5 of a file
-if (eval { require Fink::Checksum }) {
-	my $chksum = Fink::Checksum->new('MD5');
-	*_md5 = sub { $chksum->get_checksum($_[0]) };
-} else {
-	*_md5 = sub { Fink::Services::file_MD5_checksum($_[0]) };
-}
+my $chksum = Fink::Checksum->new('MD5');
+*_md5 = sub { $chksum->get_checksum($_[0]) };
 
 # Initialize Fink
 if (eval { require Fink }) {

--- a/perlmod/Fink/Services.pm
+++ b/perlmod/Fink/Services.pm
@@ -60,7 +60,7 @@ BEGIN {
 					  &parse_fullversion
 					  &collapse_space
 					  &pkglist2lol &lol2pkglist &cleanup_lol
-					  &file_MD5_checksum &get_osx_vers &enforce_gcc
+					  &get_osx_vers &enforce_gcc
 					  &get_system_perl_version &get_path
 					  &eval_conditional &count_files
 					  &get_osx_vers_long &get_kernel_vers
@@ -1235,28 +1235,6 @@ sub cleanup_lol {
 	my @clusters = grep { defined $_ } @$struct;
 	@$struct = @clusters;
 }
-
-=item file_MD5_checksum (deprecated)
-
-    my $md5 = file_MD5_checksum $filename;
-
-Returns the MD5 checksum of the given $filename. Uses /sbin/md5 if it
-is available, otherwise uses the first md5sum in PATH. The output of
-the chosen command is read via an open() pipe and matched against the
-appropriate regexp. If the command returns failure or its output was
-not in the expected format, the program dies with an error message.
-
-Note: this method is deprecated; use Fink::Checksum->new('MD5') instead.
-
-=cut
-
-sub file_MD5_checksum {
-	my $filename = shift;
-
-	my $checksum = Fink::Checksum->new('MD5');
-	return $checksum->get_checksum($filename);
-}
-
 
 =item gcc_selected
 


### PR DESCRIPTION
This PR ...
* teaches `fink dumpinfo` to output checksum fields
* makes `fink.info` use a SHA256 checksum in addition to the MD5 checksum
* adds support for `PatchFile-Checksum` which can be used instead or in addition to `PatchFile-MD5`
* gets rid of the long obsolete `file_MD5_checksum`

Once this is released, and one could start adding `PatchFile-Checksum` to .info files (indeed, a script could automatically add it to all files which already have `PatchFileN-MD5` fields).

For that, I'd recommend using SHA256 only, and not SHA1, as the latter is considered broken these days, too (just not quite as badly as MD5, but still).