### PR TITLE
Robustify dpkg build

### DIFF
--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -8,9 +8,13 @@ Source-MD5: a9f6c43891db74d727beab7dfc0ee663
 PatchFile: dpkg.patch
 PatchFile-MD5: c8e538b0f3346b62fa4464bfc698947d
 PatchScript: <<
+	#!/bin/sh -ev
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> archtable
-	cd optlib; perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in; rm getopt*
+	pushd optlib
+		perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in
+		rm getopt*
+	popd
 <<
 SetCFLAGS: -I%p/include
 NoSetMAKEFLAGS: true

--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -8,20 +8,34 @@ Source-MD5: a9f6c43891db74d727beab7dfc0ee663
 PatchFile: dpkg.patch
 PatchFile-MD5: 912dae1e60c3ccde9a7875e0c0eb3840
 PatchScript: <<
- sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
- echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> %b/archtable
+	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> archtable
 <<
 SetCFLAGS: -I%p/include
 NoSetMAKEFLAGS: true
 SetMAKEFLAGS: -j1
 CompileScript: <<
- PERL=/usr/bin/perl ./configure --build=%m-apple-darwin %c
- make
+	./configure %c
+	/usr/bin/make -w
 <<
-ConfigureParams: --without-zlib --without-dselect --without-start-stop-daemon --without-sgml-doc --with-admindir=%P/var/lib/dpkg --mandir=%p/share/man --infodir=%p/share/info --srcdir=%b  --without-libintl-prefix --without-libiconv-prefix --disable-nls
+ConfigureParams: <<
+	--build=%m-apple-darwin \
+	--without-zlib \
+	--without-dselect \
+	--without-start-stop-daemon \
+	--without-sgml-doc \
+	--with-admindir=%P/var/lib/dpkg \
+	--mandir=%p/share/man \
+	--infodir=%p/share/info \
+	--srcdir=%b \
+	--without-libintl-prefix \
+	--without-libiconv-prefix \
+	--disable-nls
+	PERL=/usr/bin/perl
+<<
 InstallScript: <<
- mkdir -p %i/share/doc/dpkg
- make install DESTDIR=%d
+	mkdir -p %i/share/doc/dpkg
+	/usr/bin/make install DESTDIR=%d
 <<
 Description: The Debian package manager (bootstrap only)
 DescDetail: <<
@@ -29,6 +43,14 @@ dpkg installs and removes binary packages; it is the base of the
 distribution. This package also contains some helper programs. This
 package does not build dselect and thus doesn't require ncurses. It is
 intended to be used during bootstrap.
+<<
+DescPackaging: <<
+  admindir goes in %P (eventual live basedir) not %p (bootstrap
+  basedir): dpkg-bootstrap needs to set up the initial live dpkg
+  status database.
+
+  removed Depends and BuildDepends since this is built during phase two
+  of bootstrap and those fields are not relevant there
 <<
 DescPort: <<
 1.10.9 
@@ -57,14 +79,6 @@ instead of relying on PATH
 
 stpncpy test may fail due to wrong prototype even if we have the
 function, so remove AIX-bug-specific hack
-<<
-DescPackaging: <<
-  admindir goes in %P (eventual live basedir) not %p (bootstrap
-  basedir): dpkg-bootstrap needs to set up the initial live dpkg
-  status database.
-
-  removed Depends and BuildDepends since this is built during phase two
-  of bootstrap and those fields are not relevant there
 <<
 License: GPL
 Homepage: http://packages.qa.debian.org/d/dpkg.html

--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -6,7 +6,7 @@ Source: mirror:sourceforge:fink/dpkg_%v.tar.gz
 SourceDirectory: dpkg-%v
 Source-MD5: a9f6c43891db74d727beab7dfc0ee663
 PatchFile: dpkg.patch
-PatchFile-MD5: 5166e45568d16d662b895e43697b3659
+PatchFile-MD5: 9c3d590be2403102773cce89556443e7
 PatchScript: <<
 	#!/bin/sh -ev
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -6,10 +6,11 @@ Source: mirror:sourceforge:fink/dpkg_%v.tar.gz
 SourceDirectory: dpkg-%v
 Source-MD5: a9f6c43891db74d727beab7dfc0ee663
 PatchFile: dpkg.patch
-PatchFile-MD5: 912dae1e60c3ccde9a7875e0c0eb3840
+PatchFile-MD5: c8e538b0f3346b62fa4464bfc698947d
 PatchScript: <<
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> archtable
+	cd optlib; perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in; rm getopt*
 <<
 SetCFLAGS: -I%p/include
 NoSetMAKEFLAGS: true
@@ -31,7 +32,8 @@ ConfigureParams: <<
 	--without-libintl-prefix \
 	--without-libiconv-prefix \
 	--disable-nls
-	PERL=/usr/bin/perl
+	PERL=/usr/bin/perl \
+	SED=/usr/bin/sed
 <<
 InstallScript: <<
 	mkdir -p %i/share/doc/dpkg
@@ -77,8 +79,34 @@ Patched to not remove Darwin's system-critical symlinks (/etc /tmp /var)
 Patched to hardcode complete paths to our component executables
 instead of relying on PATH
 
+Patch 'dpkg -b' tar invocation to avoid warning under tar>=1.16
+See: http://permalink.gmane.org/gmane.os.apple.fink.core/1281
+
+Patch 'dpkg -b' tar invocation to not die if tar returns exit code 1.
+(Exit 1 is a non-fatal error for tar; exit 2 is fatal.)  patch written by vasi
+
+Fink's make-3.81-1 breaks compiling so use Apple's to be safe.
+
+The on-board getopt needs tweaking for darwin, but isn't needed at all
+because libSystem has what dpkg needs, so just scrap it.
+
+Remove un/misused variable in dpkg enquiry.c (solve bus error in --architecture)
+
+Filesystem may be case-insensitive, so do case-insensitive check for
+"dpkg -i" replacing files in an already-installed other package
+
+Patched off-by-one bug in main/help.c:preexecscript argv processing
+(backported from upstream dpkg-1.13.16)
+
+Patched to use %p/lib/fink/dpkg-base-files/ wrappers for .deb scripts
+(for use with the dpkg-base-files module)
+NB: wrapper runs even if no .deb script.
+
 stpncpy test may fail due to wrong prototype even if we have the
 function, so remove AIX-bug-specific hack
+
+Protect build against increasingly strict character-class regex in
+sed. See: https://github.com/fink/scripts/issues/45
 <<
 License: GPL
 Homepage: http://packages.qa.debian.org/d/dpkg.html

--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -6,7 +6,7 @@ Source: mirror:sourceforge:fink/dpkg_%v.tar.gz
 SourceDirectory: dpkg-%v
 Source-MD5: a9f6c43891db74d727beab7dfc0ee663
 PatchFile: dpkg.patch
-PatchFile-MD5: c8e538b0f3346b62fa4464bfc698947d
+PatchFile-MD5: 5166e45568d16d662b895e43697b3659
 PatchScript: <<
 	#!/bin/sh -ev
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -16,7 +16,9 @@ PatchScript: <<
 		rm getopt*
 	popd
 <<
-SetCFLAGS: -I%p/include
+# not sure we want to haul in fink-package-precedence but may as well
+# stash the data for possible manual analysis
+SetCPPFLAGS: -MD
 NoSetMAKEFLAGS: true
 SetMAKEFLAGS: -j1
 CompileScript: <<
@@ -111,6 +113,9 @@ function, so remove AIX-bug-specific hack
 
 Protect build against increasingly strict character-class regex in
 sed. See: https://github.com/fink/scripts/issues/45
+
+Link build-dir libs directly and pass all local -I flags early (avoid
+masking by external/globally installed other packages).
 <<
 License: GPL
 Homepage: http://packages.qa.debian.org/d/dpkg.html

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -1,6 +1,6 @@
 Package: dpkg
 Version: 1.10.21
-Revision: 1247
+Revision: 1248
 GCC: 4.0
 BuildDepends: fink (>= 0.30.0)
 Depends: <<
@@ -20,7 +20,7 @@ Source2: mirror:gnu:gettext/gettext-0.19.8.1.tar.gz
 #Source2: mirror:sourceforge:fink/gettext-0.19.8.1.tar.gz
 Source2-MD5: 97e034cf8ce5ba73a28ff6c3c0638092
 PatchFile: %n.patch
-PatchFile-MD5: c8e538b0f3346b62fa4464bfc698947d
+PatchFile-MD5: 5166e45568d16d662b895e43697b3659
 PatchFile2: libgettext8-shlibs.patch
 PatchFile2-MD5: 9a702c97d1c95d216f0908e368e7ad42
 PatchScript: <<
@@ -36,7 +36,9 @@ PatchScript: <<
 		perl -pi -e 's/.*chmod.*777.*$//g' build-aux/ltmain.sh
 	popd
 <<
-SetCFLAGS: -I%p/include
+# not sure we want to haul in fink-package-precedence but may as well
+# stash the data for possible manual analysis
+SetCPPFLAGS: -MD
 CompileScript: <<
 	#!/bin/sh -ev
 	if [ $UID -ne 0 ]; then echo "dpkg cannot be built with --build-as-nobody"; exit 1; fi
@@ -186,6 +188,9 @@ function, so remove AIX-bug-specific hack
 
 Protect build against increasingly strict character-class regex in
 sed. See: https://github.com/fink/scripts/issues/45
+
+Link build-dir libs directly and pass all local -I flags early (avoid
+masking by external/globally installed other packages).
 <<
 License: GPL
 Homepage: http://packages.qa.debian.org/d/dpkg.html

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -24,11 +24,11 @@ PatchFile-MD5: 912dae1e60c3ccde9a7875e0c0eb3840
 PatchFile2: libgettext8-shlibs.patch
 PatchFile2-MD5: 9a702c97d1c95d216f0908e368e7ad42
 PatchScript: <<
- cd %b/..; sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p0
- cd %b/..; sed 's|@PREFIX@|%p|g' < %{PatchFile2} | patch -p0
- cd %b/../gettext-0.19.8.1/build-aux; perl -pi -e 's/.*chmod.*777.*$//g' ltmain.sh
- cd optlib; perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in; rm getopt*
- echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> %b/archtable
+	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> archtable
+	cd optlib; perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in; rm getopt*
+	cd ../gettext-0.19.8.1; sed 's|@PREFIX@|%p|g' < %{PatchFile2} | patch -p1
+	cd ../gettext-0.19.8.1/build-aux; perl -pi -e 's/.*chmod.*777.*$//g' ltmain.sh
 <<
 SetCFLAGS: -I%p/include
 CompileScript: <<
@@ -40,7 +40,7 @@ CompileScript: <<
 	### match the new package parameters (except build static only here).
 	### Not necessary, but will avoid unforeseen consequences.
 	%p/bin/fink -y install gettext-bin libgettext8-dev libiconv-dev libncurses5
-	cd %b/../gettext-0.19.8.1/gettext-tools
+	pushd %b/../gettext-0.19.8.1/gettext-tools
 	env EMACS=no JAVA=/usr/bin/java GCJ=/usr/bin/javac ./configure \
 		--prefix="%b/../_inst%p" \
 		--infodir='${prefix}/share/info' \
@@ -60,29 +60,40 @@ CompileScript: <<
 		ac_cv_path_GREP=/usr/bin/grep \
 		ac_cv_path_SED=/usr/bin/sed
 	/usr/bin/make -w
-	rm -rf %b/../_inst
+	rm -rf "%b/../_inst"
 	/usr/bin/make -w install
+	popd
 	### Now actually build dpkg using msgfmt and xgettext we just compiled
-	cd %b
-	PERL=/usr/bin/perl ac_cv_path_MSGFMT="%b/../_inst%p/bin/msgfmt" ac_cv_path_XGETTEXT="%b/../_inst%p/bin/xgettext" ./configure \
-		--build=%m-apple-darwin %c \
-		ac_cv_prog_SED=/usr/bin/sed
+	./configure %c
 	/usr/bin/make -w
 <<
 ConfigureParams: <<
+	--build=%m-apple-darwin \
 	--without-start-stop-daemon \
 	--without-sgml-doc \
 	--with-admindir=%p/var/lib/dpkg \
 	--mandir=%p/share/man \
 	--infodir=%p/share/info \
-	--srcdir=%b
+	--srcdir=%b \
+	MSGFMT="%b/../_inst%p/bin/msgfmt" \
+	XGETTEXT="%b/../_inst%p/bin/xgettext" \
+	PERL=/usr/bin/perl \
+	SED=/usr/bin/sed
 <<
 InstallScript: <<
- mkdir -p %i/share/doc/dpkg
- /usr/bin/make install DESTDIR=%d
- install -c -p -m 644 origin.fink %i/etc/dpkg/origins/fink
- rm -rf %i/lib/dpkg/methods/*
- mkdir -p -m0755 %i/lib/fink/dpkg-base-files
+	mkdir -p %i/share/doc/dpkg
+	/usr/bin/make install DESTDIR=%d
+	install -c -p -m 644 origin.fink %i/etc/dpkg/origins/fink
+	rm -rf %i/lib/dpkg/methods/*
+	mkdir -p -m0755 %i/lib/fink/dpkg-base-files
+<<
+PostInstScript: <<
+for file in diversions statoverride; do
+	if [ ! -f %p/var/lib/dpkg/$file ]; then
+  		/usr/bin/touch %p/var/lib/dpkg/$file
+  		/bin/chmod 644 %p/var/lib/dpkg/$file
+	fi
+done
 <<
 Description: The Debian package manager
 DescDetail: <<
@@ -166,15 +177,6 @@ NB: wrapper runs even if no .deb script.
 
 stpncpy test may fail due to wrong prototype even if we have the
 function, so remove AIX-bug-specific hack
-<<
-#
-PostInstScript: <<
-for file in diversions statoverride; do
-	if [ ! -f %p/var/lib/dpkg/$file ]; then
-  		/usr/bin/touch %p/var/lib/dpkg/$file
-  		/bin/chmod 644 %p/var/lib/dpkg/$file
-	fi
-done
 <<
 License: GPL
 Homepage: http://packages.qa.debian.org/d/dpkg.html

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -34,6 +34,7 @@ PatchScript: <<
 	pushd ../gettext-0.19.8.1
 		sed 's|@PREFIX@|%p|g' < %{PatchFile2} | patch -p1
 		perl -pi -e 's/.*chmod.*777.*$//g' build-aux/ltmain.sh
+		perl -pi -e 's/ examples / / if /^SUBDIRS/' 	gettext-tools/Makefile.in
 	popd
 <<
 # not sure we want to haul in fink-package-precedence but may as well

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -24,11 +24,17 @@ PatchFile-MD5: c8e538b0f3346b62fa4464bfc698947d
 PatchFile2: libgettext8-shlibs.patch
 PatchFile2-MD5: 9a702c97d1c95d216f0908e368e7ad42
 PatchScript: <<
+	#!/bin/sh -ev
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> archtable
-	cd optlib; perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in; rm getopt*
-	cd ../gettext-0.19.8.1; sed 's|@PREFIX@|%p|g' < %{PatchFile2} | patch -p1
-	cd ../gettext-0.19.8.1/build-aux; perl -pi -e 's/.*chmod.*777.*$//g' ltmain.sh
+	pushd optlib
+		perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in
+		rm getopt*
+	popd
+	pushd ../gettext-0.19.8.1
+		sed 's|@PREFIX@|%p|g' < %{PatchFile2} | patch -p1
+		perl -pi -e 's/.*chmod.*777.*$//g' build-aux/ltmain.sh
+	popd
 <<
 SetCFLAGS: -I%p/include
 CompileScript: <<

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -20,7 +20,7 @@ Source2: mirror:gnu:gettext/gettext-0.19.8.1.tar.gz
 #Source2: mirror:sourceforge:fink/gettext-0.19.8.1.tar.gz
 Source2-MD5: 97e034cf8ce5ba73a28ff6c3c0638092
 PatchFile: %n.patch
-PatchFile-MD5: 912dae1e60c3ccde9a7875e0c0eb3840
+PatchFile-MD5: c8e538b0f3346b62fa4464bfc698947d
 PatchFile2: libgettext8-shlibs.patch
 PatchFile2-MD5: 9a702c97d1c95d216f0908e368e7ad42
 PatchScript: <<
@@ -155,7 +155,7 @@ instead of relying on PATH
 Patch 'dpkg -b' tar invocation to avoid warning under tar>=1.16
 See: http://permalink.gmane.org/gmane.os.apple.fink.core/1281
 
-Patch 'dpkg -b' tar invocation to not die if tar returns exit code 1.  
+Patch 'dpkg -b' tar invocation to not die if tar returns exit code 1.
 (Exit 1 is a non-fatal error for tar; exit 2 is fatal.)  patch written by vasi
 
 Fink's make-3.81-1 breaks compiling so use Apple's to be safe.
@@ -177,6 +177,9 @@ NB: wrapper runs even if no .deb script.
 
 stpncpy test may fail due to wrong prototype even if we have the
 function, so remove AIX-bug-specific hack
+
+Protect build against increasingly strict character-class regex in
+sed. See: https://github.com/fink/scripts/issues/45
 <<
 License: GPL
 Homepage: http://packages.qa.debian.org/d/dpkg.html

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -20,7 +20,7 @@ Source2: mirror:gnu:gettext/gettext-0.19.8.1.tar.gz
 #Source2: mirror:sourceforge:fink/gettext-0.19.8.1.tar.gz
 Source2-MD5: 97e034cf8ce5ba73a28ff6c3c0638092
 PatchFile: %n.patch
-PatchFile-MD5: 5166e45568d16d662b895e43697b3659
+PatchFile-MD5: 9c3d590be2403102773cce89556443e7
 PatchFile2: libgettext8-shlibs.patch
 PatchFile2-MD5: 9a702c97d1c95d216f0908e368e7ad42
 PatchScript: <<

--- a/10.9-libcxx/dpkg.patch
+++ b/10.9-libcxx/dpkg.patch
@@ -1,13 +1,14 @@
 diff -urN dpkg-1.10.21.orig/Makefile.conf.in dpkg-1.10.21/Makefile.conf.in
 --- dpkg-1.10.21.orig/Makefile.conf.in	2012-07-13 02:12:44.000000000 +0200
-+++ dpkg-1.10.21/Makefile.conf.in	2012-07-13 02:13:27.000000000 +0200
++++ dpkg-1.10.21/Makefile.conf.in	2018-06-09 02:14:15.000000000 -0400
 @@ -60,13 +60,13 @@
  
  CPPFLAGS		= @CPPFLAGS@
  LD			= @LD@
 -LDFLAGS			= @LDFLAGS@ -L../lib -L../optlib
-+LDFLAGS			= @LDFLAGS@ -L../lib -L../optlib -framework CoreFoundation
- LIBS			= @LIBS@ -ldpkg -lopt $(ZLIB_LIBS)
+-LIBS			= @LIBS@ -ldpkg -lopt $(ZLIB_LIBS)
++LDFLAGS			= @LDFLAGS@ -framework CoreFoundation
++LIBS			= @LIBS@ ../lib/libdpkg.a ../optlib/libopt.a $(ZLIB_LIBS)
  
  RANLIB			= @RANLIB@
  
@@ -17,6 +18,15 @@ diff -urN dpkg-1.10.21.orig/Makefile.conf.in dpkg-1.10.21/Makefile.conf.in
  
  NLS_CFLAGS		= -DLOCALEDIR=\"$(localedir)\" -I$(top_srcdir)/intl -I../intl
  NLS_LIBS		= @INTLLIBS@ 
+@@ -79,7 +79,7 @@
+ ZLIB_LIBS		= @ZLIB_LIBS@
+ ZLIB_LIBS_ALSO_STATIC	= @ZLIB_LIBS_ALSO_STATIC@
+ 
+-ALL_CFLAGS		= $(CPPFLAGS) $(CFLAGS) $(DEFS) $(NLS_CFLAGS) $(INCLUDE_CFLAGS) $(ZLIB_CFLAGS)
++ALL_CFLAGS		= $(CFLAGS) $(DEFS) $(NLS_CFLAGS) $(INCLUDE_CFLAGS) $(ZLIB_CFLAGS) $(CPPFLAGS)
+ ALL_CXXFLAGS		= $(ALL_CFLAGS) $(CXXFLAGS)
+ 
+ ALSO_STATIC		= @ALSO_STATIC@
 diff -urN dpkg-1.10.21.orig/dpkg-deb/Makefile.in dpkg-1.10.21/dpkg-deb/Makefile.in
 --- dpkg-1.10.21.orig/dpkg-deb/Makefile.in	2012-07-13 02:12:44.000000000 +0200
 +++ dpkg-1.10.21/dpkg-deb/Makefile.in	2012-07-13 02:13:27.000000000 +0200

--- a/10.9-libcxx/dpkg.patch
+++ b/10.9-libcxx/dpkg.patch
@@ -3442,6 +3442,18 @@ diff -urN dpkg-1.10.21.orig/origin.fink dpkg-1.10.21/origin.fink
 +Vendor: Fink
 +Vendor-URL: http://fink.sourceforge.net/
 +Bugs: http://fink.sourceforge.net/
+diff -urN dpkg-1.10.21.orig/scripts/Makefile.in dpkg-1.10.21/scripts/Makefile.in
+--- dpkg-1.10.21.orig/scripts/Makefile.in	2018-06-09 01:49:44.000000000 -0400
++++ dpkg-1.10.21/scripts/Makefile.in	2018-06-09 01:50:14.000000000 -0400
+@@ -99,7 +99,7 @@
+ 	pod2man --section=1 $^ > $@
+ 
+ %: %.pl
+-	$(SED) -e "s:^#![:space:]*/usr/bin/perl:#! $(PERL):; \
++	$(SED) -e "s:^#![[:space:]]*/usr/bin/perl:#! $(PERL):; \
+ 		s:\$$dpkglibdir[[:space:]]*=[[:space:]]*['\"][^'\"]*['\"]:\$$dpkglibdir=\"$(dpkglibdir)\":; \
+ 		s:\$$admindir[[:space:]]*=[[:space:]]*['\"][^'\"]*['\"]:\$$admindir=\"$(admindir)\":; \
+ 		s:\$$version[[:space:]]*=[[:space:]]*['\"][^'\"]*[\"']:\$$version=\"$(VERSION)\":" \
 diff -urN dpkg-1.10.21.orig/scripts/cleanup-info.8 dpkg-1.10.21/scripts/cleanup-info.8
 --- dpkg-1.10.21.orig/scripts/cleanup-info.8	2012-07-13 02:12:44.000000000 +0200
 +++ dpkg-1.10.21/scripts/cleanup-info.8	2012-07-13 02:13:27.000000000 +0200

--- a/10.9-libcxx/dpkg.patch
+++ b/10.9-libcxx/dpkg.patch
@@ -1,7 +1,7 @@
 diff -urN dpkg-1.10.21.orig/Makefile.conf.in dpkg-1.10.21/Makefile.conf.in
 --- dpkg-1.10.21.orig/Makefile.conf.in	2012-07-13 02:12:44.000000000 +0200
-+++ dpkg-1.10.21/Makefile.conf.in	2018-06-09 02:14:15.000000000 -0400
-@@ -60,13 +60,13 @@
++++ dpkg-1.10.21/Makefile.conf.in	2018-06-09 16:17:30.000000000 -0400
+@@ -60,15 +60,15 @@
  
  CPPFLAGS		= @CPPFLAGS@
  LD			= @LD@
@@ -16,8 +16,11 @@ diff -urN dpkg-1.10.21.orig/Makefile.conf.in dpkg-1.10.21/Makefile.conf.in
 -INCLUDE_CFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir) -I$(srcdir) -I../include -I.. -I. -I$(top_srcdir)/optlib
 +INCLUDE_CFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir) -I$(srcdir) -I../include -I.. -I. -I$(top_srcdir)/optlib -F/System/Library/Frameworks/CoreFoundation.framework
  
- NLS_CFLAGS		= -DLOCALEDIR=\"$(localedir)\" -I$(top_srcdir)/intl -I../intl
+-NLS_CFLAGS		= -DLOCALEDIR=\"$(localedir)\" -I$(top_srcdir)/intl -I../intl
++NLS_CFLAGS		= -DLOCALEDIR=\"$(localedir)\"
  NLS_LIBS		= @INTLLIBS@ 
+ 
+ SSD_LIBS		= @SSD_LIBS@
 @@ -79,7 +79,7 @@
  ZLIB_LIBS		= @ZLIB_LIBS@
  ZLIB_LIBS_ALSO_STATIC	= @ZLIB_LIBS_ALSO_STATIC@


### PR DESCRIPTION
Fix for gnu sed (https://github.com/fink/scripts/issues/45) and fix lots of -I/-L ordering oddities. Once merged, remember to copy dpkg.{info,patch} into fink-distributions  (stable/base).