### PR TITLE
Added check that filesystem is HFS before running SplitForks command

### DIFF
--- a/perlmod/Fink/PkgVersion.pm
+++ b/perlmod/Fink/PkgVersion.pm
@@ -3967,7 +3967,7 @@ sub phase_install {
 		}
 		chomp (my $developer_dir=`xcode-select -print-path 2>/dev/null`);
 		$install_script .= "\n/bin/chmod -R o-w '%i/Applications/'" .
-			"\nif test -x $developer_dir/Tools/SplitForks; then $developer_dir/Tools/SplitForks '%i/Applications/'; fi";
+			"\nif test -x $developer_dir/Tools/SplitForks -a \"\$(mount | grep ' on / (hfs' )\"_x != _x ; then $developer_dir/Tools/SplitForks '%i/Applications/'; fi";
 	}
 
 	# generate commands to install jar files

--- a/perlmod/Fink/PkgVersion.pm
+++ b/perlmod/Fink/PkgVersion.pm
@@ -3967,7 +3967,7 @@ sub phase_install {
 		}
 		chomp (my $developer_dir=`xcode-select -print-path 2>/dev/null`);
 		$install_script .= "\n/bin/chmod -R o-w '%i/Applications/'" .
-			"\nif test -x $developer_dir/Tools/SplitForks -a \"\$(mount | grep ' on / (hfs' )\"_x != _x ; then $developer_dir/Tools/SplitForks '%i/Applications/'; fi";
+			"\nif /bin/test -x $developer_dir/Tools/SplitForks -a \"\$(/sbin/mount | /usr/bin/grep ' on / (hfs' )\"_x != _x ; then $developer_dir/Tools/SplitForks '%i/Applications/'; fi";
 	}
 
 	# generate commands to install jar files


### PR DESCRIPTION
Attempting to install AppBundles fails on line 3970 in perlmod/Fink/PkgVersion.pm on a 10.14 machine with APFS file systems as SplitForks expects HFS+ file systems:

`"\nif test -x $developer_dir/Tools/SplitForks; then $developer_dir/Tools/SplitForks '%i/Applications/'; fi";`

Obviously the right thing to do is to test if `%i/Applications/ `is sitting on a HFS file system before running SplitForks, although this is tricky to determine properly because either diskutil or mount require the name of the mount point in order to reveal the file system type.
I've taken the obviously easy route to punt that %i is always on the root file system / and use:

`mount | grep ' on / (hfs'`

as the check. Any suggestions for alternative approaches are welcome?