### PR TITLE
Use the correct name for the gettext-tools source tarball

### DIFF
--- a/10.9-libcxx/gettext-tools.info
+++ b/10.9-libcxx/gettext-tools.info
@@ -5,7 +5,7 @@ CustomMirror: <<
 	Primary: http://ftpmirror.gnu.org/gettext/
 	Secondary: http://downloads.sourceforge.net/fink/
 <<
-Source: mirror:custom:%n-%v.tar.gz
+Source: mirror:custom:gettext-%v.tar.gz
 Source-MD5: 97e034cf8ce5ba73a28ff6c3c0638092
 PatchFile: libgettext8-shlibs.patch
 PatchFile-MD5: 9a702c97d1c95d216f0908e368e7ad42


### PR DESCRIPTION
I was a bit too zealous with copy/paste when doing the custom mirrors in #183.