### PR TITLE
allow clang version > 9

### DIFF
--- a/perlmod/Fink/VirtPackage.pm
+++ b/perlmod/Fink/VirtPackage.pm
@@ -1279,7 +1279,7 @@ the successful execution of "/usr/bin/clang -v".
 				my ($versionoutput, $version, $build);
 				{ local $/ = undef; $versionoutput = <CLANG> }
 				close(CLANG);
-				if ($versionoutput =~ m[Apple\s(clang|LLVM)\sversion\s(\d(?:\.\d+(?:\.\d+)?)?)\s\((tags/Apple/)?clang\-(\d+(?:\.\d+(?:\.\d+)?)?)]) {
+				if ($versionoutput =~ m[Apple\s(clang|LLVM)\sversion\s(\d+(?:\.\d+(?:\.\d+)?)?)\s\((tags/Apple/)?clang\-(\d+(?:\.\d+(?:\.\d+)?)?)]) {
 					($version, $build)= ($2, $4);
 				} else {
 					print STDERR "  - warning, unable to determine the version for clang\n" if ($options{debug});


### PR DESCRIPTION
Allow for clang versions that have more than 1 digit in the leading bit of the version string.
Fixes #175