### PR TITLE
Update java download locations

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -143,11 +143,11 @@ if ($arch eq "i386") {
 				my $need_java_sdk = `/usr/bin/javac -version 2>&1>/dev/null`;
 				if ($need_java_sdk =~ m/No Java runtime present\, requesting install\./) {
 					die "Please install an Oracle JDK from\n" .
-						"http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html\n" .
+						"https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html\n" .
 						"or\n" .
-						"http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html\n" .
-						"or the Apple Legacy Java package from\n" .
-						"http://support.apple.com/downloads/DL1572/en_US/JavaForOSX2014-001.dmg\n" .
+						"https://www.oracle.com/technetwork/java/javase/downloads/index.html\n" .
+						"or the Apple Legacy Java package (macOS 10.7-10.13) from\n" .
+						"https://support.apple.com/kb/DL1572\n" .
 						"before re-attempting the fink bootstrap.\n";
 				}
 			}


### PR DESCRIPTION
* Java7 is no longer available for download, so replace with generic download link for all Javas
* provide link to Apple-java download page since actual DMG URL is not static