### PR TITLE
Find cups headers when /usr/include is not present

### DIFF
--- a/perlmod/Fink/VirtPackage.pm
+++ b/perlmod/Fink/VirtPackage.pm
@@ -242,7 +242,7 @@ in /usr/include/cups.
 END
 	$hash->{compilescript} = &gen_compile_script($hash);
 
-	if (open(FILEIN, '/usr/include/cups/cups.h')) {
+	if (open(FILEIN, Fink::Services::get_sdkpath() . '/usr/include/cups/cups.h')) {
 		while (<FILEIN>) {
 			if (/\#\s*define\s+CUPS_VERSION\s+(.*?)\s*$/) {
 				$hash->{version} = $1 . '-1';


### PR DESCRIPTION
Under 10.14+, Xcode no longer installs /usr/include but hides headers in the SDK. Find cups.h in the SDK so that cups-dev is populated.