### PR TITLE
allow zsh as SHELL in pathsetup script

### DIFF
--- a/pathsetup.sh.in
+++ b/pathsetup.sh.in
@@ -283,8 +283,6 @@ else
         SOURCECMD="test -r @PREFIX@/bin/init.sh && . @PREFIX@/bin/init.sh"
         if [ -f $HOME/.zprofile ]; then
 	    RC=.zprofile
-	elif [ -f $HOME/.zshrc ]; then
-	    RC=.zshrc
         elif [ -f $HOME/.zlogin ]; then
 	    RC=.zlogin
 	else
@@ -292,7 +290,7 @@ else
 	fi
 	case $RC in
 	  new)
-	    RC=.login
+	    RC=.zlogin
 	    MSG=msg_create
 	  ;;
 	  *)

--- a/pathsetup.sh.in
+++ b/pathsetup.sh.in
@@ -2,7 +2,7 @@
 #
 # Shell script for preparing the user's shell startup scripts for Fink.
 # Copyright (c) 2003-2005 Martin Costabel
-# Copyright (c) 2003-2016 The Fink Package Manager Team
+# Copyright (c) 2003-2019 The Fink Package Manager Team
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -20,7 +20,7 @@
 #
 
 
-# This version is tested for csh type user login shells and for bash, 
+# This version is tested for csh type user login shells, for bash, and for zsh.
 # for other sh type shells it does nothing.
 
 # Function declarations:
@@ -278,8 +278,31 @@ else
 	esac
 	display_choose_do
     ;;
+    zsh)
+    # Only zsh here; other sh type shells are not supported
+        SOURCECMD="test -r @PREFIX@/bin/init.sh && . @PREFIX@/bin/init.sh"
+        if [ -f $HOME/.zprofile ]; then
+	    RC=.zprofile
+	elif [ -f $HOME/.zshrc ]; then
+	    RC=.zshrc
+        elif [ -f $HOME/.zlogin ]; then
+	    RC=.zlogin
+	else
+	    RC=new
+	fi
+	case $RC in
+	  new)
+	    RC=.login
+	    MSG=msg_create
+	  ;;
+	  *)
+	    MSG=msg_append
+	  ;;
+	esac
+	display_choose_do
+    ;;
     *)
-    # Any shell except *csh and bash
+    # Any shell except *csh, bash, and zsh
 	Result="\n
 Since you have changed your login shell to $LOGINSHELL,
 I am confident that you know what you are doing.\n


### PR DESCRIPTION
With 10.15 defaulting to zsh, we need to give pathsetup hints as to where to look for the .bash_profile equivalent.

This writes the `test -r /opt/sw/bin/init.sh && . /opt/sw/bin/init.sh` to .zshrc, but the test for the sourcing working is not actually working. However, init.sh does work because a new terminal does have the right Fink PATH.