### PR TITLE
Conditional path

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -7,7 +7,7 @@
 #
 # Fink - a package manager that downloads source and installs it
 # Copyright (c) 2001 Christoph Pfisterer
-# Copyright (c) 2001-2019 The Fink Package Manager Team
+# Copyright (c) 2001-2021 The Fink Package Manager Team
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/bootstrap
+++ b/bootstrap
@@ -539,7 +539,7 @@ foreach my $forbidden (
 	   /usr/X11R6 /usr/X11 /opt/X11
 	   /root /private /cores /boot
 	   /debian /debian/.*
-	   /usr/local /usr/local/.* /opt/local /opt/local/.*)
+	   /usr/local /usr/local/.* /opt/local /opt/local/.* /opt/homebrew /opt/homebrew/.*)
 ) {
 	if ($installto =~ /^$forbidden$/i) {
 		print "ERROR: Refusing to install into '$installto'.\n";
@@ -557,6 +557,12 @@ foreach my $forbidden (
 			&print_breaking(
 				 "/opt/local is the default location that Macports ".
 				 "uses, so installing there is likely to lead to problems.");
+		}
+		if ($installto =~ /^\/opt\/homebrew/) {
+			&print_breaking(
+				 "/opt/homebrew is the default location that Homebrew ".
+				 "uses on M1 systems, so installing there is likely to ".
+				 "lead to problems.");
 		}
 		redo OPT_BASEPATH;
 	}

--- a/bootstrap
+++ b/bootstrap
@@ -488,17 +488,25 @@ OPT_BASEPATH: { ### install path redo block
 
 # ask if the path wasn't passed as a parameter
 if ($retrying || not $installto) {
-	my $default = '/opt/sw';
+	my $default;
+	my $install_path;
+	if ($vers <= 18) {
+		$default = '/sw';
+		$install_path = $default;
+	} else {
+		$default = '/opt/sw';
+		$install_path = $default;
+	}
 	while (1) {
-		last if !has_installed_software($default);
-		$default =~ /^(.*?)(\d*)$/;
-		$default = $1 . (($2 || 1) + 1);
+		last if !has_installed_software($install_path);
+		$install_path =~ /^(.*?)(\d*)$/;
+		$install_path = $1 . (($2 || 1) + 1);
 	}
 	
 	print "\n";
-	if ($default ne '/opt/sw' && !$nonstandard_warning) {
-		print "It looks like you already have Fink installed in /opt/sw, trying "
-		.	"$default instead.\n\n"
+	if ($install_path ne $default && !$nonstandard_warning) {
+		print "It looks like you already have Fink installed in $default, trying "
+		.	"$install_path instead.\n\n"
 		.	"WARNING: This is a non-standard location.\n\n";
 		$nonstandard_warning = 1;
 	}
@@ -506,7 +514,7 @@ if ($retrying || not $installto) {
 		. "that you will normally be able to use a binary distribution only if you "
 		. "choose '/opt/sw' (or '/sw' on systems before 10.15).";
 	$installto =
-		&prompt($prompt, default => $default);
+		&prompt($prompt, default => $install_path);
 }
 $retrying = 1;
 print "\n";


### PR DESCRIPTION
Fixes the previous commit that hardcoded every new install to try `/opt/sw` w/out considering the already existing binary distribution.
This conditionals the install path to only try `/opt/sw` for 10.15 (darwin19) and up and otherwise default to `/sw`.