### PR TITLE
README: direct users to XQuartz.org

### DIFF
--- a/README
+++ b/README
@@ -31,8 +31,8 @@ You need:
  * An installed Mac OS X system, version 10.7 or later.
 
  * The Xcode Command Line Tools are mandatory. This package can be installed
-   either by downloading it directly via developer.apple.com, or by running
-   the
+   either by downloading it directly via developer.apple.com/xcode/, or by
+   running the
 
       xcode-select --install
 
@@ -60,6 +60,9 @@ You need:
 
    from a Terminal.app window should suffice to make the system download it
    for you.
+
+ * XQuartz to satisfy x11-dev build dependencies. This package can be installed
+   by downloading it directly via https://xquartz.org.
 
  * Internet access. All source code is downloaded from mirror sites.
 

--- a/README.html
+++ b/README.html
@@ -55,8 +55,10 @@ You need:
 An installed Mac OS X system, version 10.7 or later.
 </p></li>
 <li><p>
-The Xcode Command Line Tools are mandatory. This package can be installed either by 
-downloading it directly via developer.apple.com, or by running the</p>
+The Xcode Command Line Tools are mandatory. This package can be installed
+either by downloading it directly via
+<a href="https://developer.apple.com/xcode/">developer.apple.com/xcode/</a>, or
+by running the</p>
 <pre>xcode-select --install</pre>
 <p>command and choosing the   
 <b>Install</b> button in the window that pops up.
@@ -74,6 +76,11 @@ especially if you're having build problems.</p>
 <li><p>Java.  Entering</p>
 <pre>javac</pre>
 <p>from a Terminal.app window should suffice to make the system download it for you.</p></li>
+<li><p>
+XQuartz to satisfy <pre>x11-dev</pre> build dependencies. This package can be
+installed by downloading it directly via
+<a href="https://xquartz.org">XQuartz.org</a>.
+</p></li>
 <li><p>
 Internet access.
 All source code is downloaded from mirror sites.


### PR DESCRIPTION
Very few packages can be installed without x11-dev. Include
instructions on resolving this dependency.

Refine xcode url to developer.apple.com/xcode/
