### PR TITLE
Remove -bind_at_load flag from dpkg bootstrapping.

### DIFF
--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -11,7 +11,7 @@ SourceDirectory: dpkg-%v
 
 UpdateConfigGuessInDirs: build-aux
 PatchFile: dpkg.patch
-PatchFile-MD5: 9fb88eddbf7d830c448eb7771642bb3a
+PatchFile-MD5: 82f5c581d07a327c4bbd3ca1c7a39f28
 
 PatchScript: <<
 sed -e 's,@FINKPREFIX@,%p,g' -e 's,@ARCHITECTURE@,%m,g' %{PatchFile} | patch -p1
@@ -109,7 +109,7 @@ perl -pi -e "s,GNU patch,patch,g" configure
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -fPIE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-align -Wno-format-security
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2
 SetCXXFLAGS: -g -O2 -fstack-protector -Wformat -fPIE
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 
 # Use %P for all state and admindirs for pre fink build
 ConfigureParams: <<

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -39,7 +39,7 @@ SourceDirectory: dpkg-%v
 
 UpdateConfigGuessInDirs: build-aux
 PatchFile: dpkg.patch
-PatchFile-MD5: 9fb88eddbf7d830c448eb7771642bb3a
+PatchFile-MD5: 82f5c581d07a327c4bbd3ca1c7a39f28
 
 PatchScript: <<
 sed -e 's,@FINKPREFIX@,%p,g' -e 's,@ARCHITECTURE@,%m,g' %{PatchFile} | patch -p1
@@ -141,7 +141,7 @@ perl -pi -e "s,-q '[\^]GNU patch,-qE '^\(GNU \)\?patch,g" configure
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -fPIE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-align -Wno-format-security
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2
 SetCXXFLAGS: -g -O2 -fstack-protector -Wformat -fPIE
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 
 ConfigureParams: <<
 	--with-finkvirtuals=%p/bin/fink-virtual-pkgs \

--- a/10.9-libcxx/dpkg.patch
+++ b/10.9-libcxx/dpkg.patch
@@ -17,7 +17,7 @@ diff -ruN dpkg-1.19.7.orig/fink/buildflags.conf dpkg-1.19.7/fink/buildflags.conf
 +APPEND LDFLAGS -fPIE -Wl,-pie
 +
 +# debian relro
-+APPEND LDFLAGS -Wl,-read_only_stubs
++# APPEND LDFLAGS -Wl,-read_only_stubs
 +
 +# debian bindnow
 +APPEND LDFLAGS -Wl,-bind_at_load


### PR DESCRIPTION
Xcode15 removed support for this flag, which is i386 only. See #255.