### PR TITLE
Support macOS 27 (beta)

### DIFF
--- a/perlmod/Fink/Bootstrap.pm
+++ b/perlmod/Fink/Bootstrap.pm
@@ -159,7 +159,7 @@ sub host_supported_if {
 	} else {
 		&print_breaking("This system was not released at the time " .
 			"this Fink release was made.  Prerelease versions " .
-			"of OS X might work with Fink, but there are no " .
+			"of macOS might work with Fink, but there are no " .
 			"guarantees.");
 	}
 }
@@ -251,8 +251,12 @@ GCC_MSG
 		$distribution = "15.0";
 	} elsif ($host =~ /^(aarch64|x86_64)-apple-darwin25\.(\d+)\.\d+$/) {
 		# last macOS version that will support x86_64
-		&host_supported_if($2 =~ /^[0-5]$/);
+		&host_supported_if($2 =~ /^[0-6]$/);
 		$distribution = "26.0";
+	} elsif ($host =~ /^(aarch64|x86_64)-apple-darwin27\.(\d+)\.\d+$/) {
+		# last macOS version to fully support Rosetta 2 (no native x86_64 systems)
+		&host_supported_if($2 =~ /^[1-1]$/);
+		$distribution = "27.0";
 	} else {
 		&print_breaking("This system is unrecognized and not ".
 			"supported by Fink.");
@@ -1104,6 +1108,7 @@ sub get_selfupdatetrees {
 		"14.4" => "10.9-libcxx",
 		"15.0" => "10.9-libcxx",
 		"26.0" => "10.9-libcxx",
+		"27.0" => "10.9-libcxx",
 		);
 
 	return $selfupdatetrees{$distribution};

--- a/perlmod/Fink/Services.pm
+++ b/perlmod/Fink/Services.pm
@@ -1478,7 +1478,8 @@ sub get_osx_vers {
 			'13.7' => 13.5,
 			'14.7' => 14.6,
 			'14.8' => 14.6,
-			'15.7' => 15.6);
+			'15.7' => 15.6,
+			'27.0' => 28.0);
 		die "$sw_vers does not match the expected value of $darwin_osx. Please run `fink selfupdate` to download a newer version of fink"
 			unless $sw_to_darwin{$sw_vers} == $darwin_osx;
 	}


### PR DESCRIPTION
Adding Tahoe 26.6 and Golden Gate 27.0 (not yet as officially supported) to known sw_vers.
Tested to inject and bootstrap on 27 developer beta 6 with a couple of core packages built (some of course requiring Distribution updates in fink-distributions).